### PR TITLE
clone: __x86_64__: Align initial stack pointer to 10h.

### DIFF
--- a/src/linux_syscall_support.h
+++ b/src/linux_syscall_support.h
@@ -1450,6 +1450,13 @@ struct kernel_statfs {
                              "testq  %5,%5\n"
                              "jz     1f\n"
 
+                             /* Set up alignment of the child stack:
+                              * child_stack &= ~ 0xF;
+                              * The compiler may rely on RSP being aligned to 10h bytes
+                              * before any call to a compiled function.
+                              */
+                             "andb  $-16, %5\n"
+
                              /* childstack -= 2*sizeof(void *);
                               */
                              "subq   $16,%5\n"
@@ -1478,7 +1485,7 @@ struct kernel_statfs {
 
                              /* In the child. Terminate frame pointer chain.
                               */
-                             "xorq   %%rbp,%%rbp\n"
+                             "xorl   %%ebp,%%ebp\n"
 
                              /* Call "fn(arg)".
                               */


### PR DESCRIPTION
Compiler relies on RSP being aligned to 16-byte boundary before any CALL to a compiled function, in order to easily align stack objects.

When issuing a syscall with __NR_clone, we get to specify the initial stack pointer for the child thread.

This changeset ensures that the stack pointer specified by our caller (local_clone) is adjusted so that it is properly aligned to 16-byte boundary (as for __i386__).

Another thing that has been changed: In order to put 0 into RBP, "xor rbp, rbp" can be replaced with "xor ebp, ebp", thus saving one byte of machine code (the REX prefix). Reason: If the destination operand of an instruction is a 32-bit general purpose register, the other 32 bits of the 64-bit general purpose register are automatically filled with zero by the CPU (as per AMD64 documentation).

Thank you for your work and for considering this changeset !  (-: