### PR TITLE
Cope with the removal of sys/sysctl.h in recent glibc/kernel.

### DIFF
--- a/configure
+++ b/configure
@@ -16857,12 +16857,6 @@ then :
   printf "%s\n" "#define HAVE_SYS_STAT_H 1" >>confdefs.h
 
 fi
-ac_fn_c_check_header_compile "$LINENO" "sys/sysctl.h" "ac_cv_header_sys_sysctl_h" "$ac_includes_default"
-if test "x$ac_cv_header_sys_sysctl_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_SYSCTL_H 1" >>confdefs.h
-
-fi
 ac_fn_c_check_header_compile "$LINENO" "sys/time.h" "ac_cv_header_sys_time_h" "$ac_includes_default"
 if test "x$ac_cv_header_sys_time_h" = xyes
 then :

--- a/configure.ac
+++ b/configure.ac
@@ -26,8 +26,8 @@ AC_SUBST(LIBTOOL_DEPS)
 
 AC_CHECK_HEADERS([elf.h errno.h fcntl.h linux/unistd.h pthread.h signal.h     \
                   stdlib.h string.h sys/prctl.h sys/ptrace.h sys/resource.h   \
-                  sys/socket.h sys/stat.h sys/sysctl.h sys/time.h sys/types.h \
-                  sys/uio.h sys/wait.h unistd.h])
+                  sys/socket.h sys/stat.h sys/time.h sys/types.h sys/uio.h \
+                  sys/wait.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics
 AC_C_CONST

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -54,9 +54,6 @@
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #undef HAVE_SYS_STAT_H
 
-/* Define to 1 if you have the <sys/sysctl.h> header file. */
-#undef HAVE_SYS_SYSCTL_H
-
 /* Define to 1 if you have the <sys/time.h> header file. */
 #undef HAVE_SYS_TIME_H
 

--- a/src/elfcore.c
+++ b/src/elfcore.c
@@ -50,7 +50,6 @@ extern "C" {
 #include <sys/prctl.h>
 #include <sys/procfs.h>
 #include <sys/socket.h>
-#include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/uio.h>
 #include <sys/wait.h>


### PR DESCRIPTION
Hi,

We had this small patch since couple of years on our Amadeus fork. Since I am rebasing our Amadeus fork on yours, I am contributing this in your repository ;)

I tried to compile this (and re-generate the autotools files using `autoreconf --install`) in a fedora 36 docker mage, where `sys/sysctl.h` has already disappeared.

Cheers,
Romain